### PR TITLE
Cleaned Up the component behaviour class

### DIFF
--- a/PnT/ecs/include/component.h
+++ b/PnT/ecs/include/component.h
@@ -6,10 +6,22 @@
 #pragma once
 #include "log.h"
 
+#define P_GET_COMPONENT_TYPE(type) static PComponentType s_GetStaticType() { return type; } \
+                                virtual PComponentType getComponentType() const override { return s_GetStaticType(); } \
+                                virtual const char* getName() const override { return #type; }  \
+
+
+
 namespace pnt::ecs {
 
     class PEntity; // Forward declaration
 
+    enum class PComponentType{
+        PTransformComponent,
+        PRenderComponent,
+        PMeshComponent,
+        PBehaviourScriptComponent
+    };
 
     class PComponent {
     public:
@@ -22,7 +34,12 @@ namespace pnt::ecs {
 
         [[nodiscard]] inline unsigned int getID() const{ return m_id; }
 
+        virtual PComponentType getComponentType() const = 0;
+
+        virtual const char* getName() const = 0;
+
         PEntity* m_entity;
+
     protected:
         unsigned int m_id;
     };

--- a/PnT/ecs/include/mesh.h
+++ b/PnT/ecs/include/mesh.h
@@ -22,6 +22,8 @@ namespace pnt::ecs{
 
         void initBuffers();
 
+        P_GET_COMPONENT_TYPE(PComponentType::PMeshComponent)
+
 #ifdef HACK_
     inline VertexBuffer* getVBO() { return &m_vertexBuffer; }
     inline ElementBuffer* getEBO() { return &m_elementBuffer; }

--- a/PnT/ecs/include/renderer.h
+++ b/PnT/ecs/include/renderer.h
@@ -18,6 +18,8 @@ namespace pnt::ecs{
         void update(float deltaTime) override;
         void start() override;
 
+        P_GET_COMPONENT_TYPE(PComponentType::PRenderComponent)
+
 
     private:
         static unsigned int s_count; // All components must have this

--- a/PnT/ecs/include/scripting.h
+++ b/PnT/ecs/include/scripting.h
@@ -17,6 +17,9 @@ namespace pnt::ecs{
         void update(float deltaTime) override;
 
         void start() override;
+
+        P_GET_COMPONENT_TYPE(PComponentType::PBehaviourScriptComponent)
+
     private:
         static unsigned int s_count; // All components must have this
     };

--- a/PnT/ecs/include/transform_ecs.h
+++ b/PnT/ecs/include/transform_ecs.h
@@ -66,6 +66,8 @@ namespace pnt::ecs{
         void update(float deltaTime) override;
         void start() override;
 
+        P_GET_COMPONENT_TYPE(PComponentType::PTransformComponent)
+
     private:
         static unsigned int s_count; // All components must have this
 

--- a/PnT/ecs/src/components_behavior.cpp
+++ b/PnT/ecs/src/components_behavior.cpp
@@ -23,4 +23,8 @@ namespace pnt::ecs{
     PEntityBase *ManipulativeBehaviour::getEntityBase(PEntity *entity) const {
         return dynamic_cast<PEntityBase*>(entity);
     }
+
+    PTransformComponent *ManipulativeBehaviour::getTransform(PEntity *entity) const {
+        return entity->m_transform;
+    }
 }

--- a/PnT/ecs/src/transform_ecs.cpp
+++ b/PnT/ecs/src/transform_ecs.cpp
@@ -35,4 +35,5 @@ namespace pnt::ecs{
     void PTransformComponent::start() {
         PComponent::start();
     }
+
 }

--- a/PnT/geometry/src/mesh_system_conc.cpp
+++ b/PnT/geometry/src/mesh_system_conc.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "mesh_system_conc.h"
+#include "entity.h"
 
 namespace pnt::mesh{
     void P3DGeometricMeshSS::init() {
@@ -35,6 +36,12 @@ namespace pnt::mesh{
 
     PMeshComponent *P3DGeometricMeshSS::AddComponent(PEntity *entity) {
         try {
+            // Avoid multiple mesh components on one entity
+            for (const auto& component : meshComponents){
+                if (component->getID() == entity->getInstanceId()) {
+                    return component.get();
+                }
+            }
             meshComponents.emplace_back(std::make_unique<PMeshComponent>(entity));
             return meshComponents.back().get();
         } catch (...) {

--- a/PnT/renderer/src/render_system_conc.cpp
+++ b/PnT/renderer/src/render_system_conc.cpp
@@ -6,6 +6,7 @@
 #include "log.h"
 #include "data_hash_table.h"
 #include "fileio.h"
+#include "entity.h"
 
 namespace pnt::graphics {
 
@@ -100,6 +101,12 @@ namespace pnt::graphics {
 
     PRenderComponent *POpenGLRenderSS::AddComponent(PEntity *entity) {
         try {
+            // Avoid multiple render components on one entity
+            for (const auto& component : renderComponents){
+                if (component->getID() == entity->getInstanceId()) {
+                    return component.get();
+                }
+            }
             renderComponents.emplace_back(std::make_unique<PRenderComponent>(entity));
             return renderComponents.back().get();
         } catch (...) {
@@ -110,6 +117,7 @@ namespace pnt::graphics {
 
     PRenderComponent *POpenGLRenderSS::GetComponent(unsigned int id) {
         try{
+            // Get the Component that has the same id as the entity, we use that because only one component type can be on the entity.
             for (const auto& component : renderComponents) {
                 if (component->getID() == id) {
                     return component.get();
@@ -138,6 +146,6 @@ namespace pnt::graphics {
     }
 
     std::vector<PRenderComponent *> POpenGLRenderSS::FindComponentsByTag(PEntity *entity, std::string tag) {
-        return std::vector<PRenderComponent *>();
+        return {};
     }
 }

--- a/PnT/scene/src/transform_system_conc.cpp
+++ b/PnT/scene/src/transform_system_conc.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "transform_system_conc.h"
+#include "entity.h"
 
 void pnt::scene::PTransformSS::init() {
 
@@ -30,6 +31,12 @@ void pnt::scene::PTransformSS::destroy() {
 
 PTransformComponent *pnt::scene::PTransformSS::AddComponent(PEntity *entity) {
     try {
+        // Avoid multiple transform components on one entity
+        for (const auto& component : transformComponents){
+            if (component->getID() == entity->getInstanceId()) {
+                return component.get();
+            }
+        }
         transformComponents.emplace_back(std::make_unique<PTransformComponent>(entity));
         return transformComponents.back().get();
     } catch (...) {


### PR DESCRIPTION
Redirected lookup of components to the local container in the entity.

Add check for duplicate components in add component function in the systems to enforce 1 Entity -  1 ComponentType rule.